### PR TITLE
Rename ClientConfig record as ConnectionConfig

### DIFF
--- a/mongodb/Module.md
+++ b/mongodb/Module.md
@@ -22,12 +22,12 @@ import ballerinax/mongodb;
 ```
 
 ### Step 2: Create a new connector instance
-Create a `mongodb:ClientConfig` with connection details obtained, and initialize the connector with it.
+Create a `mongodb:ConnectionConfig` with connection details obtained, and initialize the connector with it.
 
 To use the MongoDB client you need to specify the database it needs to connect to. If you plan to use this client to connect to single database then you can pass the database name along with the other configurations required for client initialization(optional). Alternatively, you can pass the database name for each remote method call. This is not recommended unless you need to connect to more than one database using the client.
 
 ```ballerina
-mongodb:ClientConfig mongoConfig = {
+mongodb:ConnectionConfig mongoConfig = {
     host: <YOUR_HOST_NAME>,
     port: <PORT>,
     username: <DB_USERNAME>,

--- a/mongodb/client.bal
+++ b/mongodb/client.bal
@@ -27,9 +27,9 @@ public isolated client class Client {
     private final handle datasource;
     private final string database;
 
-    # Initialises the `Client` object with the provided `ClientConfig` properties.
+    # Initialises the `Client` object with the provided `ConnectionConfig` properties.
     # 
-    # + config - `ClientConfig` properties. Even though all fields are optional, in order to authenticate the database, 
+    # + config - `ConnectionConfig` properties. Even though all fields are optional, in order to authenticate the database, 
     #             relavent fields should be given in config record. Following are some examples :
     #             (1) Username, Password
     #             (2) URL - Connection URL
@@ -37,7 +37,7 @@ public isolated client class Client {
     #             
     # + databaseName - Database name to connect
     # + return - A `mongodb:Error` if there is any error in the provided configurations or database name
-    public isolated function init(ClientConfig config, @display {label: "Database Name"} string? databaseName = ())
+    public isolated function init(ConnectionConfig config, @display {label: "Database Name"} string? databaseName = ())
                                   returns Error? {
         final ConnectionProperties? configOptions = config?.options;
         if (configOptions is ConnectionProperties) {
@@ -251,7 +251,7 @@ public isolated client class Client {
     }
 }
 
-isolated function initClient(ClientConfig config) returns handle|ApplicationError = @java:Method {
+isolated function initClient(ConnectionConfig config) returns handle|ApplicationError = @java:Method {
     'class: "org.ballerinalang.mongodb.MongoDBDataSourceUtil"
 } external;
 

--- a/mongodb/samples/count_documents.bal
+++ b/mongodb/samples/count_documents.bal
@@ -10,7 +10,7 @@ configurable string collection = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/delete.bal
+++ b/mongodb/samples/delete.bal
@@ -10,7 +10,7 @@ configurable string collection = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/get_all_collection_names.bal
+++ b/mongodb/samples/get_all_collection_names.bal
@@ -9,7 +9,7 @@ configurable string database = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/get_all_db_names.bal
+++ b/mongodb/samples/get_all_db_names.bal
@@ -8,7 +8,7 @@ configurable string password = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/insert.bal
+++ b/mongodb/samples/insert.bal
@@ -10,7 +10,7 @@ configurable string collection = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/list_indices.bal
+++ b/mongodb/samples/list_indices.bal
@@ -10,7 +10,7 @@ configurable string collection = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/query.bal
+++ b/mongodb/samples/query.bal
@@ -10,7 +10,7 @@ configurable string collection = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/samples/update.bal
+++ b/mongodb/samples/update.bal
@@ -10,7 +10,7 @@ configurable string collection = ?;
 
 public function main() {
     
-    mongodb:ClientConfig mongoConfig = {
+    mongodb:ConnectionConfig mongoConfig = {
         host: host,
         port: port,
         username: username,

--- a/mongodb/tests/main_test.bal
+++ b/mongodb/tests/main_test.bal
@@ -22,14 +22,14 @@ string testHostName = os:getEnv("MONGODB_HOST") != "" ? os:getEnv("MONGODB_HOST"
 string testUser = os:getEnv("MONGODB_USER") != "" ? os:getEnv("MONGODB_USER") : "";
 string testPass = os:getEnv("MONGODB_PASSWORD") != "" ? os:getEnv("MONGODB_PASSWORD") : "";
 
-ClientConfig mongoConfig = {
+ConnectionConfig mongoConfig = {
     host: testHostName,
     username: testUser,
     password: testPass,
     options: {sslEnabled: false, serverSelectionTimeout: 15000}
 };
 
-ClientConfig mongoConfigError = {
+ConnectionConfig mongoConfigError = {
     options: {
         url: "asdakjdk"
     }

--- a/mongodb/tests/ssl_connection_test.bal
+++ b/mongodb/tests/ssl_connection_test.bal
@@ -20,7 +20,7 @@ import ballerina/test;
 
 string jksFilePath = check file:getAbsolutePath("tests/resources/mongodb-client.jks");
 
-ClientConfig mongoConfigInvalid = {
+ConnectionConfig mongoConfigInvalid = {
    host: testHostName,
    username: testUser,
    options: {
@@ -28,7 +28,7 @@ ClientConfig mongoConfigInvalid = {
    }
 };
 
-ClientConfig sslMongoConfig = {
+ConnectionConfig sslMongoConfig = {
     host: testHostName,
     username: testUser,
     options: {

--- a/mongodb/types.bal
+++ b/mongodb/types.bal
@@ -23,8 +23,8 @@ import ballerina/crypto;
 # + username - Username for the database connection
 # + password - Password for the database connection
 # + options - Properties for the connection configuration
-@display {label: "Client Config"}
-public type ClientConfig record {|
+@display {label: "Connection Config"}
+public type ConnectionConfig record {|
     @display {label: "Host"}
     string host?;
     @display {label: "Port"}


### PR DESCRIPTION
## Purpose
- Change connector configuration record name to `ConnectionConfig`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3
