### PR TITLE
Provide support for all update operators

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=org.ballerinalang.mongodb
-version=3.2.0
+version=3.2.1
 ballerinaLangVersion=2201.0.0

--- a/mongodb-native/src/main/java/org/ballerinalang/mongodb/MongoDBCollectionUtil.java
+++ b/mongodb-native/src/main/java/org/ballerinalang/mongodb/MongoDBCollectionUtil.java
@@ -165,8 +165,7 @@ public class MongoDBCollectionUtil {
         }
         Document filterDoc = Document.parse(filter.toString());
 
-        Document updateDoc = new Document();
-        updateDoc.put("$set", Document.parse(update));
+        Document updateDoc = Document.parse(update);
 
         UpdateOptions updateOptions = new UpdateOptions().upsert(upsert);
 

--- a/mongodb/Ballerina.toml
+++ b/mongodb/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.0.0"
 org = "ballerinax"
 name = "mongodb"
-version = "3.2.0"
+version = "3.2.1"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Databases", "Cost/Freemium"]
@@ -10,7 +10,7 @@ icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-mongodb"
 
 [[platform.java11.dependency]]
-path = "../mongodb-native/build/libs/mongodb-native-3.2.0-all.jar"
+path = "../mongodb-native/build/libs/mongodb-native-3.2.1-all.jar"
 groupId = "org.ballerinalang"
 artifactId = "mongodb-native"
-version = "3.2.0"
+version = "3.2.1"

--- a/mongodb/Dependencies.toml
+++ b/mongodb/Dependencies.toml
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "mongodb"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/mongodb/client.bal
+++ b/mongodb/client.bal
@@ -140,15 +140,16 @@ public isolated client class Client {
     
     # Updates a document based on a condition.
     #
-    # + set - Document for the update condition
+    # + updateStatement - Document for the update condition. Eg: { "$set": { <field1>: <value1>, ... } } , 
+    #                     { "$push": { <field>: { "$each": [ <value1>, <value2> ... ] } } }.
     # + collectionName - Name of the collection
     # + databaseName - Name of the database
-    # + filter - Filter for the query
+    # + filter - Filter for the query. Eg: { <field1>: <value1>, ... }.
     # + isMultiple - Whether to update multiple documents
     # + upsert - Whether to insert if update cannot be achieved
     # + return - JSON array of the documents in the collection or else a `mongodb:Error` if unable to reach the DB
     @display {label: "Update Document"}
-    remote isolated function update(@display {label: "Document to Update"} map<json> set, 
+    remote isolated function update(@display {label: "Document to Update"} map<json> updateStatement, 
                                     @display {label: "Collection Name"} string collectionName, 
                                     @display {label: "Database Name"} string? databaseName = (),
                                     @display {label: "Filter for Query"} map<json>? filter = (), 
@@ -156,7 +157,7 @@ public isolated client class Client {
                                     @display {label: "Is Upsert"} boolean upsert = false) 
                                     returns @display {label: "Number of Updated Documents"} int|Error {
         handle collection = check getCollection(self, collectionName, databaseName);
-        string updateDoc = set.toJsonString();
+        string updateDoc = updateStatement.toJsonString();
         if (filter is ()) {
             return update(collection, java:fromString(updateDoc), (), isMultiple, upsert);
         }
@@ -221,7 +222,7 @@ isolated function insert(handle collection, handle document) returns DatabaseErr
 } external;
 
 isolated function update(handle collection, handle update, handle? filter, boolean isMultiple, boolean upsert)
-                returns int|DatabaseError = @java:Method {
+                returns int|Error = @java:Method {
     'class: "org.ballerinalang.mongodb.MongoDBCollectionUtil"
 } external;
 

--- a/mongodb/tests/main_test.bal
+++ b/mongodb/tests/main_test.bal
@@ -223,7 +223,7 @@ function testUpdateDocument() returns Error? {
     log:printInfo("------------------ Updating Data -------------------");
 
     map<json> replaceFilter = {name: "The Lion King"};
-    map<json> replaceDoc = {name: "The Lion King", year: "2019", rating: 6};
+    map<json> replaceDoc = { "$set": {name: "The Lion King", year: "2019", rating: 6}};
 
     var modifiedCount = mongoClient->update(replaceDoc, COLLECTION_NAME, (), replaceFilter, false);
     if (modifiedCount is int) {
@@ -235,7 +235,7 @@ function testUpdateDocument() returns Error? {
     }
 
     replaceFilter = {rating: 7};
-    replaceDoc = {rating: 9};
+    replaceDoc = { "$inc": {rating: 2}};
 
     modifiedCount = mongoClient->update(replaceDoc, COLLECTION_NAME, (), replaceFilter, true);
     if (modifiedCount is int) {
@@ -255,7 +255,7 @@ function testUpdateDocumentUpsertTrue() returns Error? {
     log:printInfo("------------------ Updating Data (Upsert) -------------------");
 
     map<json> replaceFilter = {name: "The Lion King 2"};
-    map<json> replaceDoc = {name: "The Lion King 2", year: "2019", rating: 7};
+    map<json> replaceDoc = { "$set": {name: "The Lion King 2", year: "2019", rating: 7}};
 
     var modifiedCount = mongoClient->update(replaceDoc, COLLECTION_NAME, (), replaceFilter, true, true);
     if (modifiedCount is int) {


### PR DESCRIPTION
## Purpose
> Support update operators other than $set for MongoDB Connector: Resolves https://github.com/ballerina-platform/ballerina-extended-library/issues/59.

## Goals
> Support update operators other than $set for MongoDB Connector

## Approach
> In current connector, it allows user to provide a parameter called `set` in the format of `map<json>` to update operation. Using this, connector supports only `$set` update operator. In this new implementation, user is requested to provide a parameter called `updateStatement` instead of `set` in the format of `map<json>`. It will provide the support for all update operators such as   $set, $inc, $push, $addToSet etc. 


## Release note
> This will be a minor version release. current version is 3.2.0 . New version after this change will be 3.2.1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Learning
> https://docs.mongodb.com/v4.2/reference/operator/update/