### PR TITLE
Revamp ConnectionConfig records

### DIFF
--- a/mongodb/client.bal
+++ b/mongodb/client.bal
@@ -23,20 +23,19 @@ public isolated client class Client {
 
     # Initialises the `Client` object with the provided `ConnectionConfig` properties.
     # 
-    # + config - `ConnectionConfig` properties. Even though all fields are optional, in order to authenticate the database, 
-    #             relavent fields should be given in config record. Following are some examples :
-    #             (1) Username, Password
-    #             (2) URL - Connection URL
-    #             (3) Username, secureSocket, authMechanism etc.        
+    # + config - `ConnectionConfig` properties.   
     # + return - A `mongodb:Error` if there is any error in the provided configurations or database name
     public isolated function init(ConnectionConfig config) returns Error? {
-        final ConnectionProperties? configOptions = config?.options;
-        if (configOptions is ConnectionProperties) {
-            final boolean? sslEnabled = configOptions?.sslEnabled;
-            if (sslEnabled is boolean) {
-                if (sslEnabled && configOptions?.secureSocket is ()) {
-                    return error ApplicationError("The connection property `secureSocket` is mandatory " +
-                    "when ssl is enabled for connection.");
+        if config.connection is ConnectionParameters {
+            ConnectionParameters connectionParams = <ConnectionParameters>config.connection;
+            final ConnectionProperties? configOptions = connectionParams.options;
+            if configOptions is ConnectionProperties {
+                final boolean? sslEnabled = configOptions?.sslEnabled;
+                if sslEnabled is boolean {
+                    if (sslEnabled && configOptions?.secureSocket is ()) {
+                        return error ApplicationError("The connection property `secureSocket` is mandatory " +
+                        "when ssl is enabled for connection.");
+                    }
                 }
             }
         }

--- a/mongodb/samples/count_documents.bal
+++ b/mongodb/samples/count_documents.bal
@@ -9,13 +9,19 @@ configurable string database = ?;
 configurable string collection = ?;
 
 public function main() returns error? {
-    
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000},
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
         databaseName: database
     };
 

--- a/mongodb/samples/delete.bal
+++ b/mongodb/samples/delete.bal
@@ -11,11 +11,18 @@ configurable string collection = ?;
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000},
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
         databaseName: database
     };
 

--- a/mongodb/samples/get_all_collection_names.bal
+++ b/mongodb/samples/get_all_collection_names.bal
@@ -10,11 +10,19 @@ configurable string database = ?;
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000}
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
+        databaseName: database
     };
 
     mongodb:Client mongoClient = check new (mongoConfig);

--- a/mongodb/samples/get_all_db_names.bal
+++ b/mongodb/samples/get_all_db_names.bal
@@ -9,11 +9,19 @@ configurable string password = ?;
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000}
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
+        databaseName: database
     };
 
     mongodb:Client mongoClient = check new (mongoConfig);

--- a/mongodb/samples/insert.bal
+++ b/mongodb/samples/insert.bal
@@ -11,11 +11,18 @@ configurable string collection = ?;
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000},
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
         databaseName: database
     };
 

--- a/mongodb/samples/list_indices.bal
+++ b/mongodb/samples/list_indices.bal
@@ -17,11 +17,18 @@ type Index record {
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000},
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
         databaseName: database
     };
 

--- a/mongodb/samples/query.bal
+++ b/mongodb/samples/query.bal
@@ -16,11 +16,18 @@ type Movie record {
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000},
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
         databaseName: database
     };
 

--- a/mongodb/samples/update.bal
+++ b/mongodb/samples/update.bal
@@ -11,11 +11,18 @@ configurable string collection = ?;
 public function main() returns error? {
     
     mongodb:ConnectionConfig mongoConfig = {
-        host: host,
-        port: port,
-        username: username,
-        password: password,
-        options: {sslEnabled: false, serverSelectionTimeout: 5000},
+        connection: {
+            host: host,
+            port: port,
+            auth: {
+                username: username,
+                password: password
+            },
+            options: {
+                sslEnabled: false, 
+                serverSelectionTimeout: 5000
+            } 
+        },
         databaseName: database
     };
 

--- a/mongodb/tests/main_test.bal
+++ b/mongodb/tests/main_test.bal
@@ -26,15 +26,22 @@ const DATABASE_NAME = "moviecollection";
 const COLLECTION_NAME = "moviedetails";
 
 ConnectionConfig mongoConfig = {
-    host: testHostName,
-    username: testUser,
-    password: testPass,
-    options: {sslEnabled: false, serverSelectionTimeout: 15000},
+    connection: {
+        host: testHostName,
+        auth: {
+            username: testUser,
+            password: testPass
+        },
+        options: {
+            sslEnabled: false, 
+            serverSelectionTimeout: 15000
+        } 
+    },
     databaseName: DATABASE_NAME
 };
 
 ConnectionConfig mongoConfigError = {
-    options: {
+    connection: {
         url: "asdakjdk"
     },
     databaseName: "MyDb"

--- a/mongodb/tests/ssl_connection_test.bal
+++ b/mongodb/tests/ssl_connection_test.bal
@@ -20,32 +20,40 @@ import ballerina/test;
 
 string jksFilePath = check file:getAbsolutePath("tests/resources/mongodb-client.jks");
 
+X509Credential x509Credential = {
+    username: testUser
+};
+
 ConnectionConfig mongoConfigInvalid = {
-   host: testHostName,
-   username: testUser,
-   options: {
-       sslEnabled: true
-   }
+    connection: {
+        host: testHostName,
+        auth: x509Credential,
+        options: {
+            sslEnabled: true
+        }
+    }
 };
 
 ConnectionConfig sslMongoConfig = {
-    host: testHostName,
-    username: testUser,
-    options: {
-        socketTimeout: 10000,
-        authMechanism: "MONGODB-X509",
-        sslEnabled: true,
-        sslInvalidHostNameAllowed: true,
-        secureSocket: {
-            trustStore: {
-                path: jksFilePath,
-                password: "123456"
-            },
-            keyStore: {
-                path: jksFilePath,
-                password: "123456"
-            },
-            protocol:"TLS"
+    connection: {
+        host: testHostName,
+        auth: x509Credential,
+        options: {
+            socketTimeout: 10000,
+            authMechanism: "MONGODB-X509",
+            sslEnabled: true,
+            sslInvalidHostNameAllowed: true,
+            secureSocket: {
+                trustStore: {
+                    path: jksFilePath,
+                    password: "123456"
+                },
+                keyStore: {
+                    path: jksFilePath,
+                    password: "123456"
+                },
+                protocol:"TLS"
+            }
         }
     },
     databaseName: "admin"

--- a/mongodb/types.bal
+++ b/mongodb/types.bal
@@ -18,40 +18,79 @@ import ballerina/crypto;
 
 # Represents the Client configurations for MongoDB.
 #
-# + host - The database's host address
-# + port - The port on which the database is running
-# + username - Username for the database connection
-# + password - Password for the database connection
-# + options - Properties for the connection configuration
+# + connection - Connection parameters or Connection URL to connect to MongoDB
 # + databaseName - Database name to connect. This is optional. You can pass the database name in each
 #                  remote function as well.The precedence will be given to the database name which is passed
 #                  in the remote function. 
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
-    @display {label: "Host"}
-    string host?;
-    @display {label: "Port"}
-    int port?;
-    @display {label: "Username"}
-    string username?;
-    @display {label: "Password"}
-    string password?;
-    @display {label: "Connection Options"}
-    ConnectionProperties options?;
+    @display {label: "Connection"} 
+    ConnectionParameters|ConnectionURL connection;
     @display {label: "Database Name"} 
     string databaseName?;
 |};
 
+# Connection URL.
+#
+# + url - URL
+public type ConnectionURL record {|
+    string url;
+|};
+
+# Connection Parameters
+#
+# + host - The database's host address (Default: localhost)
+# + port - The port on which the database is running (Default: 27017)
+# + auth - Basic auth Credential or X509 Credential or GSSAPI Credential 
+# + options - Properties for the connection configuration
+public type ConnectionParameters record {|
+    @display {label: "Host"}
+    string host = "localhost";
+    @display {label: "Port"}
+    int port = 27017;
+    BasicAuthCredential|X509Credential|GSSAPICredential auth;
+    @display {label: "Connection Options"}
+    ConnectionProperties options?;
+|};
+
+# Basic Authentication
+#
+# + username - Username for the database connection
+# + password - Password for the database connection
+public type BasicAuthCredential record {|
+    @display {label: "Username"}
+    string username;
+    @display {label: "Password"}
+    string password;
+|};
+
+# X509 Credential
+#
+# + username - Username (Optional)
+public type X509Credential record {|
+    @display {label: "Username"}
+    string username?;
+|};
+
+# GSSAPI Credential
+#
+# + username - Username
+# + serviceName - GSSAPI Service Name
+public type GSSAPICredential record {|
+    @display {label: "Username"}
+    string username;
+    @display {label: "Service Name"}
+    string serviceName?;
+|};
+
 # Represents the MongoDB connection pool properties
 # 
-# + url - MongoDB URL for connecting to replicas
 # + readConcern - The read concern to use
 # + writeConcern - The write concern to use. The default value is `WriteConcern.ACKNOWLEDGED`
 # + readPreference - The read preference for the replica set
 # + authSource - The source in which the user is defined
 # + authMechanism - Authentication mechanism to use. 
 #                   Possible values are PLAIN, SCRAM_SHA_1, SCRAM_SHA_256, MONGODB-X509, or GSSAPI
-# + gssapiServiceName - Authentications GSSAPI Service name
 # + replicaSet - The replica set name if it is to connect to replicas
 # + sslEnabled - Whether SSL connection is enabled
 # + sslInvalidHostNameAllowed - Whether invalid host names should be allowed
@@ -71,8 +110,6 @@ public type ConnectionConfig record {|
 #                        determine the current state of each server in the cluster.
 @display {label: "Connection Properties"}
 public type ConnectionProperties record {|
-    @display {label: "URL"}
-    string url?;
     @display {label: "Read Concern"}
     string readConcern?;
     @display {label: "Write Concern"}
@@ -83,8 +120,6 @@ public type ConnectionProperties record {|
     string authSource?;
     @display {label: "Auth Mechanism"}
     string authMechanism?;
-    @display {label: "GSS API Service Name"}
-    string gssapiServiceName?;
     @display {label: "Replica Set"}
     string replicaSet?;
     @display {label: "SSL Enabled"}


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2-enterprise/choreo/issues/15201

## Description
The `ConnectionConfig` record is changed as 
```ballerina
public type ConnectionConfig record {|
    @display {label: "Connection"} 
    ConnectionParameters|ConnectionURL connection;
    @display {label: "Database Name"} 
    string databaseName?;
|};
```

User has an option to use either ConnectionURL or ConnectionParameters.
`ConnectionParameters` record looks like 
```ballerina
public type ConnectionParameters record {|
    @display {label: "Host"}
    string host = "localhost";
    @display {label: "Port"}
    int port = 27017;
    BasicAuthCredential|X509Credential|GSSAPICredential auth;
    @display {label: "Connection Options"}
    ConnectionProperties options?;
|};
```

Here, default values are set for both host and port.
User can use `BasicAuthCredential` or `X509Credential` or `GSSAPICredential`
Other optional connection properties can be set via `options` field