### PR TITLE
Bump bal version as 2201.7.0 in release workflows

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -36,7 +36,7 @@ jobs:
                 ./gradlew build
 
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action/@2201.2.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                 args:
                   pack mongodb
@@ -46,7 +46,7 @@ jobs:
                 
             - name: Push to Staging
               if: github.event.inputs.bal_central_environment == 'STAGE'
-              uses: ballerina-platform/ballerina-action/@2201.2.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args:
                       push
@@ -57,7 +57,7 @@ jobs:
                   
             - name: Push to Dev
               if: github.event.inputs.bal_central_environment == 'DEV'
-              uses: ballerina-platform/ballerina-action/@2201.2.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args:
                       push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
                 ./gradlew build
 
             - name: Ballerina Build
-              uses: ballerina-platform/ballerina-action/@2201.2.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                 args:
                   pack mongodb
@@ -37,7 +37,7 @@ jobs:
                 JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
                 
             - name: Ballerina Push
-              uses: ballerina-platform/ballerina-action/@2201.2.1
+              uses: ballerina-platform/ballerina-action/@2201.7.0
               with:
                   args:
                       push


### PR DESCRIPTION
# Description
- Update bal version as 2201.7.0 in release workflows

## Related issue
- https://github.com/wso2-enterprise/choreo/issues/22438